### PR TITLE
Created compareDoubles method in tests;

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,7 +1,0 @@
-<component name="ProjectCodeStyleConfiguration">
-  <code_scheme name="Project" version="173">
-    <ScalaCodeStyleSettings>
-      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
-    </ScalaCodeStyleSettings>
-  </code_scheme>
-</component>

--- a/src/test/scala/cse250/pa3/DataToolsTests.scala
+++ b/src/test/scala/cse250/pa3/DataToolsTests.scala
@@ -29,10 +29,10 @@ class DataToolsTests extends AnyFlatSpec
   /**
    * Method to compare doubles with a specified degree of precision.
    */
-  val epsilon: Double = 0.001
+  val EPSILON: Double = 0.0001
 
   def compareDoubles(d1: Double, d2: Double): Boolean = {
-    Math.abs(d1 - d2) < epsilon
+    Math.abs(d1 - d2) < EPSILON
   }
 
   "loadHealthRecords" must "Load HealthRecords" in 

--- a/src/test/scala/cse250/pa3/DataToolsTests.scala
+++ b/src/test/scala/cse250/pa3/DataToolsTests.scala
@@ -26,6 +26,15 @@ import cse250.objects.HealthRecordBirthday
  */
 class DataToolsTests extends AnyFlatSpec
 {
+  /**
+   * Method to compare doubles with a specified degree of precision.
+   */
+  val epsilon: Double = 0.001
+
+  def compareDoubles(d1: Double, d2: Double): Boolean = {
+    Math.abs(d1 - d2) < epsilon
+  }
+
   "loadHealthRecords" must "Load HealthRecords" in 
   {
     val records = DataTools.loadHealthRecords(
@@ -89,9 +98,9 @@ class DataToolsTests extends AnyFlatSpec
 
     assert(!(dist contains "Mon Sep 07 00:00:00 EDT 1925"), "You're loading birthdays instead of zip codes")
     assert(dist contains "14214")
-    assert(dist("14214") == 0.03)
+    assert(compareDoubles(dist("14214"), 0.03))
     assert(dist contains "14211")
-    assert(dist("14211") == 0.05)
+    assert(compareDoubles(dist("14211"), 0.05))
   }
 
   "computeHealthRecordDist" must "Compute Statistics for Birthday" in 
@@ -104,6 +113,6 @@ class DataToolsTests extends AnyFlatSpec
 
     assert(!(dist contains "14214"), "You're loading zip codes instead of birthdays")
     assert(dist contains "Mon Sep 07 00:00:00 EDT 1925")
-    assert(dist("Mon Sep 07 00:00:00 EDT 1925") == 0.01)
+    assert(compareDoubles(dist("Mon Sep 07 00:00:00 EDT 1925"), 0.01))
   }
 }


### PR DESCRIPTION
Comparing doubles using the equivalence operator (`==`) is not consistent in
all cases, this method works to solve that by using a fixed value of
precision while doing comparisons.
Credit:
Jesse Hartloff, hartloff@buffalo.edu
Nick Brown, njbrown4@buffalo.edu
John Abramo, jmabramo@buffalo.edu